### PR TITLE
use SHIFTER_APP_URL from environment variable

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,11 +16,6 @@ jobs:
         SHIFTER_USER: ${{ secrets.SHIFTER_USER }}
         SHIFTER_PASS: ${{ secrets.SHIFTER_PASS }}
         SHIFTER_SITE_ID: ${{ secrets.SHIFTER_SITE_ID }}
-    - name: Replace ShifterURL
-      env:
-        SHIFTER_APP_URL: ${{ steps.start.outputs.shifter_app_url }}
-      run:
-        sed "s@REPLACE_SHIFTER_URL@$SHIFTER_APP_URL@" gatsby-config.js -i
     - name: setup node
       uses: actions/setup-node@v1
       with:
@@ -28,6 +23,8 @@ jobs:
     - name: install
       run: npm install
     - name: build
+      env:
+        SHIFTER_APP_URL: ${{ steps.start.outputs.shifter_app_url }}
       run: npm run build
     - name: Deploy to netlify
       uses: netlify/actions/cli@master

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -62,7 +62,7 @@ module.exports = {
         // This is field under which it's accessible
         fieldName: `wpgraphql`,
         // Url to query from
-        url: `REPLACE_SHIFTER_URL/graphql/`,
+        url: process.env.SHIFTER_APP_URL + `/graphql/`,
       },
     },
     `gatsby-plugin-react-helmet`,


### PR DESCRIPTION
SHIFTER_APP_URL 環境変数を直接ビルドで使用します。

ローカルのgatsby develop/buildのときにも、gatsbyコマンドの前に書くと使えるようになります。

```
$ SHIFTER_APP_URL="今起動してるShifterのWP" gatsby develop
```

```
$ SHIFTER_APP_URL="今起動してるShifterのWP" gatsby build
```